### PR TITLE
Add mypy pyproject.toml snippet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -467,8 +467,9 @@ be impractical (not an exhaustive list):
 
 To leverage the power of type hints, the following configuration snippet should
 be added to `pyproject.toml`. This helps the user during the linting process by
-ensuring that all functions have type definitions, with the exception of test
-functions.
+ensuring that all functions, including tests, have type definitions and checks
+for any typing issues even if a function does not have explicit type hints on
+it.
 
 ```toml
 [tool.mypy]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,6 +465,21 @@ be impractical (not an exhaustive list):
 - when making small changes or
 - contributions to projects not owned by the team.
 
+To leverage the power of type hints, the following configuration snippet should
+be added to `pyproject.toml`. This helps the user during the linting process by
+ensuring that all functions have type definitions, with the exception of test
+functions.
+
+```toml
+[tool.mypy]
+check_untyped_defs = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+```
+
 The type hints should be checked with `mypy`. More information on
 type hints can be found here: [PEP 484](https://peps.python.org/pep-0484/).
 


### PR DESCRIPTION
This PR adds a mypy pyproject.toml snippet that can enhance the linting process ([reference to case](https://github.com/canonical/upload-charm-docs/pull/32/files#r1060286466)).

It makes sure that all functions are typed with the exception of test files.