### PR TITLE
docs(PRs): Add section on request changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@
 - [Programming Languages and Frameworks](#programming-languages-and-frameworks)
 - [Repository Setup](#repository-setup)
 - [Static Code Analysis](#static-code-analysis)
+- [Subprocess calls within Python](#subprocess-calls-within-python)
 - [Test Coverage](#test-coverage)
 - [Test Structure](#test-structure)
 - [Type Hints](#type-hints)
 - [When to use Python or Shell](#when-to-use-python-or-shell)
-- [Subprocess calls within Python](#subprocess-calls-within-python)
 
 ## Programming Languages and Frameworks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@
 - [Docstrings](#docstrings)
 - [f-strings](#f-strings)
 - [Failing Status Checks](#failing-status-checks)
-- [PR comments and requests for changes](#pr-comments-and-requests-for-changes)
 - [Formatting Log Messages](#formatting-log-messages)
 - [Non Compliant Code](#non-compliant-code)
+- [PR comments and requests for changes](#pr-comments-and-requests-for-changes)
 - [Programming Languages and Frameworks](#programming-languages-and-frameworks)
 - [Repository Setup](#repository-setup)
 - [Static Code Analysis](#static-code-analysis)
@@ -227,13 +227,26 @@ the `is-charms` team as reviewer
 
 ## PR comments and requests for changes
 
-Github allows you to `request changes` on a PR, meaning it cannot be merged
-until the changes are accepted. Our team favors commenting in the usual case and
-resorting to requesting changes only if there is something problematic. It is
-adviseable to comment and let the engineer take action rather than request
-changes and block the PR. As the team is distributed, requesting changes as a
-default slows down merges and requires the reviewer to approve again. The
-preferred way is to comment instead.
+The team uses Github for reviewing changes in the codebase and integrating them
+within our projects. A reviewer can comment and give feedback that potentially
+leads to new changes in the submitted code. Github allows you to `request
+changes` on a PR, meaning it cannot be merged until the changes are accepted. As
+the team is distributed, requesting changes as a default slows down merges and
+requires the reviewer to approve again. Even with sufficient approvals, a PR
+cannot be merged unless the requestor accepts the changes, which might be
+trivial.
+
+Our team favors commenting in the usual case and resorting to requesting changes
+only if there is something problematic. It is adviseable to comment and let the
+engineer take action rather than request changes and block the PR. The preferred
+way is to comment instead.  Note that committing new changes will reset
+approvals either way and approvals need to be collected again, which is the
+expected behavior and part of our workflow.
+
+With commenting rather than requesting changes, an engineer gives feedback and
+still allows the majority of the team (based on approvals) to decide the way
+forward - a change might make it in a different PR or the change might not be
+desireable in the end.
 
 ## Failing Status Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - [Docstrings](#docstrings)
 - [f-strings](#f-strings)
 - [Failing Status Checks](#failing-status-checks)
+- [PR comments and requests for changes](#pr-comments-and-requests-for-changes)
 - [Formatting Log Messages](#formatting-log-messages)
 - [Non Compliant Code](#non-compliant-code)
 - [Programming Languages and Frameworks](#programming-languages-and-frameworks)
@@ -223,6 +224,16 @@ the `is-charms` team as reviewer
 ```
 *       @canonical/is-charms
 ```
+
+## PR comments and requests for changes
+
+Github allows you to `request changes` on a PR, meaning it cannot be merged
+until the changes are accepted. Our team favors commenting in the usual case and
+resorting to requesting changes only if there is something problematic. It is
+adviseable to comment and let the engineer take action rather than request
+changes and block the PR. As the team is distributed, requesting changes as a
+default slows down merges and requires the reviewer to approve again. The
+preferred way is to comment instead.
 
 ## Failing Status Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,12 +241,16 @@ only if there is something problematic. It is adviseable to comment and let the
 engineer take action rather than request changes and block the PR. The preferred
 way is to comment instead.  Note that committing new changes will reset
 approvals either way and approvals need to be collected again, which is the
-expected behavior and part of our workflow.
+expected behavior and part of our workflow. Please note we expect the engineer
+that raised the PR to deal with the comments in good faith, i.e., not just mark
+them as resolved when they are not really resolved for the purpose of being able
+to merge the PR.
 
 With commenting rather than requesting changes, an engineer gives feedback and
-still allows the majority of the team (based on approvals) to decide the way
-forward - a change might make it in a different PR or the change might not be
-desireable in the end.
+still allows the team (based on approvals) to decide the way forward - a change
+might make it in a different PR or the change might not be desireable in the
+end. The best approach is having as much feedback from as many engineers as
+possible to be able to reach a sound decision.
 
 ## Failing Status Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,8 @@ approvals either way and approvals need to be collected again, which is the
 expected behavior and part of our workflow. Please note we expect the engineer
 that raised the PR to deal with the comments in good faith, i.e., not just mark
 them as resolved when they are not really resolved for the purpose of being able
-to merge the PR.
+to merge the PR. The engineer that raised the PR is responsible for closing the
+comments once they are tackled.
 
 With commenting rather than requesting changes, an engineer gives feedback and
 still allows the team (based on approvals) to decide the way forward - a change


### PR DESCRIPTION
This PR adds a note on our team preference to have PR comments as a default and resort to `request changes` only if there is something really problematic.