### PR TITLE
add requirement for signed commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,7 @@ exposes our team and Canonical to operational risks.
 - Approvals reset on any new commits.
 - PRs can only be merged if all checks pass.
 - Bypassing of the rules is disabled.
+- Commits must be signed.
 
 The above configuration ensures our team processes around changes are enforced
 and provides access to the repository even if some team members are unavailable.

--- a/development-setup.md
+++ b/development-setup.md
@@ -125,11 +125,15 @@ sudo apt-get install gnupg
 gpg --gen-key
 ```
 
-* List generated keys and note the `<long_key>
+* List generated keys and note the `<long_key>`
 
 ```bash
 gpg --list-secret-keys --keyid-format LONG
+```
 
+Output:
+
+```bash
 /home/username/.gnupg/secring.gpg
 -------------------------------
 sec   4096R/<long_key> <date> [expires: <date>]
@@ -143,7 +147,7 @@ ssb   4096R/<value> <date>
 gpg --armor --export <long_key>
 ```
 
-* Go to your GitHub settings and add the gpg key:
+* Go to your GitHub settings and add the gpg public key:
   https://github.com/settings/keys
 
 * Configure git to sign commits:

--- a/development-setup.md
+++ b/development-setup.md
@@ -10,6 +10,7 @@ not cover all the static code analysis tools mentioned.
     - [Table of Contents](#table-of-contents)
     - [Python](#python)
     - [VS Code](#vs-code)
+    - [Signed Commits](#signed-commits)
 
 ### Python
 
@@ -106,4 +107,48 @@ excludesFile = ~/.gitignore_global
 "editor.rulers": [
     80, 99
 ]
+```
+
+### Signed Commits
+
+* Make sure `gpg` is installed:
+
+```bash
+sudo apt-get install gnupg
+```
+
+* Generate a new key following the prompts and entering your Canonical email
+  address. Note that, if you add a passphrase, you will need to enter that
+  passphrase on every commit unless you setup further tooling.
+
+```bash
+gpg --gen-key
+```
+
+* List generated keys and note the `<long_key>
+
+```bash
+gpg --list-secret-keys --keyid-format LONG
+
+/home/username/.gnupg/secring.gpg
+-------------------------------
+sec   4096R/<long_key> <date> [expires: <date>]
+uid                          <name> <<email>>
+ssb   4096R/<value> <date>
+```
+
+* Get the public key
+
+```bash
+gpg --armor --export <long_key>
+```
+
+* Go to your GitHub settings and add the gpg key:
+  https://github.com/settings/keys
+
+* Configure git to sign commits:
+
+```bash
+git config --global user.signingkey <long_key>
+git config --global commit.gpgsign true
 ```


### PR DESCRIPTION
As we progress towards using self-hosted runners, we will change our repository settings to require signed commits as per feedback from the security team. This PR changes the repository setup to require signed commits and adds a guide for how to enable signed commits.