### PR TITLE
Add instruction specific for MacOS to sign commits

### DIFF
--- a/development-setup.md
+++ b/development-setup.md
@@ -113,46 +113,69 @@ excludesFile = ~/.gitignore_global
 
 * Make sure `gpg` is installed:
 
-```bash
-sudo apt-get install gnupg
-```
+   * On Linux
+
+     ```bash
+     sudo apt-get install gnupg
+     ```
+     
+   * On MacOS
+
+     ```bash
+     brew install gnup pinentry-mac
+     ```
 
 * Generate a new key following the prompts and entering your Canonical email
   address. Note that, if you add a passphrase, you will need to enter that
   passphrase on every commit unless you setup further tooling.
 
-```bash
-gpg --gen-key
-```
+  ```bash
+  gpg --gen-key
+  ```
 
 * List generated keys and note the `<long_key>`
 
-```bash
-gpg --list-secret-keys --keyid-format LONG
-```
+  ```bash
+  gpg --list-secret-keys --keyid-format LONG
+  ```
 
-Output:
+  Output:
 
-```bash
-/home/username/.gnupg/secring.gpg
--------------------------------
-sec   4096R/<long_key> <date> [expires: <date>]
-uid                          <name> <<email>>
-ssb   4096R/<value> <date>
-```
+  ```bash
+  /home/username/.gnupg/secring.gpg
+  -------------------------------
+  sec   4096R/<long_key> <date> [expires: <date>]
+  uid                          <name> <<email>>
+  ssb   4096R/<value> <date>
+  ```
 
 * Get the public key
 
-```bash
-gpg --armor --export <long_key>
-```
+  ```bash
+  gpg --armor --export <long_key>
+  ```
 
 * Go to your GitHub settings and add the gpg public key:
   https://github.com/settings/keys
 
 * Configure git to sign commits:
 
-```bash
-git config --global user.signingkey <long_key>
-git config --global commit.gpgsign true
-```
+  ```bash
+  git config --global user.signingkey <long_key>
+  git config --global commit.gpgsign true
+  ```
+
+* On MacOS some extra steps are required:
+
+  ```bash
+  echo "pinentry-program /opt/homebrew/bin/pinentry-mac" >> ~/.gnupg/gpg-agent.conf
+  killall gpg-agent
+  ```
+
+  You can test if it works properly using:
+
+  ```bash
+  echo "test" | gpg --clearsign
+  ```
+
+  A prompt should ask for your password and a PGP Signature should be printed in your shell.


### PR DESCRIPTION
In order to have gpg signature to work on MacOS some extra configuration is required