### PR TITLE
add note regarding forks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,10 +302,11 @@ exposes our team and Canonical to operational risks.
 - PRs from forks should not be merged directly into the default branch if any of
   the CI/CD cannot be run (e.g., because it requires a secret). This is because
   there might be issues with the PR that are missed because certain checks did
-  not run. These PRs should be redirected to a separate branch and then have a
-  PR raised from that branch to the default branch. The branch protection of a
-  repo should not allow branches from forks to be merged directly into the
-  default branch.
+  not run. These PRs should be redirected to a separate branch (prefixed with
+  `fork-*`) and then have a PR raised from that branch to the default branch.
+  The PR should link to the original PR from the fork for reference. The branch
+  protection of a repo should not allow branches from forks to be merged
+  directly into the default branch.
 
 The above configuration ensures our team processes around changes are enforced
 and provides access to the repository even if some team members are unavailable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,6 +299,13 @@ exposes our team and Canonical to operational risks.
 - PRs can only be merged if all checks pass.
 - Bypassing of the rules is disabled.
 - Commits must be signed.
+- PRs from forks should not be merged directly into the default branch if any of
+  the CI/CD cannot be run (e.g., because it requires a secret). This is because
+  there might be issues with the PR that are missed because certain checks did
+  not run. These PRs should be redirected to a separate branch and then have a
+  PR raised from that branch to the default branch. The branch protection of a
+  repo should not allow branches from forks to be merged directly into the
+  default branch.
 
 The above configuration ensures our team processes around changes are enforced
 and provides access to the repository even if some team members are unavailable.


### PR DESCRIPTION
This PR follows on from this conversation: https://github.com/canonical/operator-workflows/pull/93#issuecomment-1427182448

It proposes that PRs from forks should be redirected at a separate branch if any of the status checks cannot be run (which means that any repos using `operator-workflows` need to have this be done). The branch protection can be updated to decline PRs directly from forks using a similar pattern as the required status checks job. PR to be created.