### PR TITLE
Add step adding the SSH key as a signing key

### DIFF
--- a/development-setup.md
+++ b/development-setup.md
@@ -196,4 +196,8 @@ git config --global user.signingkey path/to/your/ssh/key
 git config --global commit.gpgsign true
 ```
 
+* Add the SSH key to [GitHub](https://github.com/settings/keys) as a new SSH
+  signing key. This is required even if you already have the same key configured
+  as an authentication key.
+
 * Voilà


### PR DESCRIPTION
Add a step to the signed commit guide for SSH keys as a signing key adding a required step to add the SSH key as a signing key.