### PR TITLE
Use step-down rule for of the order of function policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -669,10 +669,7 @@ Without a logical order, it can be difficult to follow modules and classes as
 the number of functions or methods on them grow increasing the maintenance
 burden of the code.
 
-On modules, where a function depends on another function, the dependent function
-should be listed after the function it depends on. This means that the functions
-with the fewest dependencies on other functions in the module should be listed
-first. Functions should also be grouped logically. If functions have a similar
+Functions should be grouped logically. If functions have a similar
 purpose, they should be grouped together.
 
 On classes, the `__init__` method should come first followed by any other

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -674,8 +674,8 @@ Functions should be ordered according to the
 This means that a module should be readable from top to bottom, 
 with functions ordered by level of abstraction, from general to specific. 
 A calling function should always be above the called function. 
-Functions should also be grouped together logically. If functions have a similar purpose,
-they should be grouped together.
+Functions should also be grouped together logically. If functions have a
+similar purpose, they should be grouped together.
 
 
 On classes, the `__init__` method should come first followed by any other

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -669,8 +669,14 @@ Without a logical order, it can be difficult to follow modules and classes as
 the number of functions or methods on them grow increasing the maintenance
 burden of the code.
 
-Functions should be grouped logically. If functions have a similar
-purpose, they should be grouped together.
+Functions should be ordered according to the 
+["step-down"](https://dzone.com/articles/the-stepdown-rule) rule.
+This means that a module should be readable from top to bottom, 
+with functions ordered by level of abstraction, from general to specific. 
+A calling function should always be above the called function. 
+Functions should also be grouped together logically. If functions have a similar purpose,
+they should be grouped together.
+
 
 On classes, the `__init__` method should come first followed by any other
 factory methods, such as `from_charm`. The rest of the methods on a class should


### PR DESCRIPTION
This is a follow-up to https://github.com/canonical/is-charms-contributing-guide/pull/68/files. 

The guideline to list the dependent function after the function it depends on is removed by this PR, as this guideline has not been followed in many PRs, and there seems to be consensus that the team favours the step-down rule.