### PR TITLE
Update review dismissal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ exposes our team and Canonical to operational risks.
 - The default branch is called `main`.
 - The default branch is protected and can only be changed using PRs.
 - The number of approvers for PRs is 2.
-- Approvals reset on any new commits.
+- Approvals are not dismissed on new commits.
 - PRs can only be merged if all checks pass.
 - Bypassing of the rules is disabled.
 - Commits must be signed.


### PR DESCRIPTION
Update review dismissal. Reviews won't be dismissed when new commits are pushed