### PR TITLE
remove src-docs recommendation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -628,53 +628,6 @@ Note:
 This ensures consistency across our projects, catches many potential bugs
 before code is deployed and simplifies PRs.
 
-## Source Code Documentation
-
-* This section of the documentation applies to charm repositories.
-
-In order to make PRs easier to review,
-[lazydocs](https://github.com/ml-tooling/lazydocs) is used to generate source
-code documentation from Python docstrings. It is recommended to install
-pre-commit hooks to run tox `src-docs` testing environment.
-
-The contents of tox `src-docs` testing environment are as follows:
-```
-[testenv:src-docs]
-allowlist_externals=sh
-description = Generate documentation for src
-deps =
-    lazydocs
-    -r{toxinidir}/requirements.txt
-commands =
-    ; can't run lazydocs directly due to needing to run it on src/* which
-    ; produces an invocation error in tox
-    sh generate-src-docs.sh
-```
-
-The environment above requires `generate-src-docs.sh` to be present at the root
-directory. The contents of `generate-src-docs.sh` are as follows:
-
-```bash
-#!/usr/bin/env bash
-
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-rm -rf src-docs # remove deleted class docs that persist
-lazydocs --no-watermark --output-path src-docs src/*
-```
-
-The entire workflow can be triggered via git pre-commit hook. Run the following
-command at the root directory of the git repository to install the pre-commit
-hook.
-```bash
-echo -e "tox -e src-docs\ngit add src-docs\n" > .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
-
-On a successful commit, the markdown documentation is generated under `src-docs`
-directory.
-
 ## Function and Method Ordering
 
 Without a logical order, it can be difficult to follow modules and classes as


### PR DESCRIPTION
It has been agreed that we no longer rely on src-docs in our repos.